### PR TITLE
Add support for example annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Examples may now be skipped by adding `@tag :skip` before them. (https://github.com/iamvery/elixir-koans/pull/13)
+- Examples may now be focused on by adding `@tag :focus` before them. (https://github.com/iamvery/elixir-koans/pull/13)
+
 ### Changed
 - Rewording and additional examples throughout "asserts" and "numbers and booleans" (https://github.com/iamvery/elixir-koans/pull/12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Rewording and additional examples throughout "asserts" and "numbers and booleans" (https://github.com/iamvery/elixir-koans/pull/12)
+
 ## [v1]
 
 ### Fixed

--- a/lib/koans.ex
+++ b/lib/koans.ex
@@ -54,8 +54,19 @@ defmodule Koans do
   def run do
     koans
     # TODO lazy iteration
+    |> focus
     |> Enum.reverse
     |> Enum.each(&exec/1)
+  end
+
+  defp focus(koans) do
+    focused_koans = Enum.filter(koans, fn {_,_,tag} -> tag == :focus end)
+
+    if Enum.empty?(focused_koans) do
+      koans
+    else
+      focused_koans
+    end
   end
 
   defp exec({module, koan, _tag}) do

--- a/lib/koans.ex
+++ b/lib/koans.ex
@@ -58,7 +58,7 @@ defmodule Koans do
     |> Enum.each(&exec/1)
   end
 
-  defp exec({module, koan}) do
+  defp exec({module, koan, _tag}) do
     try do
       apply(module, koan, [])
     rescue
@@ -71,8 +71,11 @@ defmodule Koans do
   defmacro think(message, lesson) do
     name = :"#{message}"
     quote do
+      tag = Module.get_attribute(__MODULE__, :tag)
+      Module.put_attribute(__MODULE__, :tag, nil)
+
       Module.put_attribute(__MODULE__, :meditation, unquote(message))
-      Koans.add({__MODULE__, unquote(name)})
+      Koans.add({__MODULE__, unquote(name), tag})
       def unquote(name)(), do: unquote(lesson)
     end
   end

--- a/lib/koans.ex
+++ b/lib/koans.ex
@@ -52,7 +52,10 @@ defmodule Koans do
   end
 
   def run do
-    koans |> Enum.reverse |> Enum.each(&exec/1)
+    koans
+    # TODO lazy iteration
+    |> Enum.reverse
+    |> Enum.each(&exec/1)
   end
 
   defp exec({module, koan}) do

--- a/lib/koans.ex
+++ b/lib/koans.ex
@@ -85,9 +85,11 @@ defmodule Koans do
       tag = Module.get_attribute(__MODULE__, :tag)
       Module.put_attribute(__MODULE__, :tag, nil)
 
-      Module.put_attribute(__MODULE__, :meditation, unquote(message))
-      Koans.add({__MODULE__, unquote(name), tag})
-      def unquote(name)(), do: unquote(lesson)
+      unless tag == :skip do
+        Module.put_attribute(__MODULE__, :meditation, unquote(message))
+        Koans.add({__MODULE__, unquote(name), tag})
+        def unquote(name)(), do: unquote(lesson)
+      end
     end
   end
 


### PR DESCRIPTION
Examples can be tagged with `:focus` or `:skip`

``` elixir
@tag :skip
think "this example won't be run" do
  # ...
end

@tag :focus
think "only this example will be run" do
  # ...
end
```
