### PR TITLE
Consider flipping examples with comparions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+- Actual value on left, expected on right (https://github.com/iamvery/elixir-koans/pull/14)
 - Prettier user feedback when running koans (https://github.com/iamvery/elixir-koans/pull/37)
 - Various house cleanings (https://github.com/iamvery/elixir-koans/pull/36)
 

--- a/about_asserts.exs
+++ b/about_asserts.exs
@@ -19,10 +19,10 @@ defmodule AboutAsserts do
   end
 
   think "To understand reality, we must compare our expectations against reality." do
-    expected_value = __?
     actual_value = 1 + 1
+    expected_value = __?
 
-    assert expected_value == actual_value
+    assert actual_value == expected_value
   end
 
   think "Assertions are smart" do

--- a/about_atoms.exs
+++ b/about_atoms.exs
@@ -3,7 +3,7 @@ defmodule AboutAtoms do
 
   think "Atoms are sort of like strings" do
     adam = :human
-    assert __? == adam
+    assert adam == __?
   end
 
   think "Strings can be converted to atoms, and vice versa" do
@@ -15,8 +15,8 @@ defmodule AboutAtoms do
     map = %{name: "Jay"}
     list = [name: "Jay"]
 
-    assert __? == map[:name]
-    assert __? == list[:name]
+    assert map[:name] == __?
+    assert list[:name] == __?
   end
 
   think "Only atom keys may be accessed with dot syntax" do
@@ -38,18 +38,18 @@ defmodule AboutAtoms do
   think "It is surprising to find out that booleans are atoms" do
     assert_? is_atom(true)
     assert_? is_atom(false)
-    assert __? == :true
-    assert __? == :false
+    assert :true == __?
+    assert :false == __?
   end
 
   think "Modules are also atoms" do
     assert_? is_atom(String)
-    assert __? == :"Elixir.String"
-    assert __? == :"Elixir.String".upcase("hello")
+    assert :"Elixir.String" == __?
+    assert :"Elixir.String".upcase("hello") == __?
   end
 
   think "Atoms are used to access Erlang" do
     assert_? :erlang.is_list([])
-    assert __? == :lists.sort([2, 3, 1])
+    assert :lists.sort([2, 3, 1]) == __?
   end
 end

--- a/about_lists_and_maps.exs
+++ b/about_lists_and_maps.exs
@@ -34,7 +34,7 @@ defmodule AboutListsAndMaps do
     list = [1, 2, 3]
     [a, _, c] = list
 
-    assert __? == a and __? == c
+    assert a == __? and c == __?
     assert_raise MatchError, fn -> __? = list end
   end
 

--- a/about_processes.exs
+++ b/about_processes.exs
@@ -9,7 +9,7 @@ defmodule AboutProcesses do
   think "Spawning a process returns a process ID (PID)" do
     pid = spawn fn -> IO.puts "I am running in another process" end
 
-    assert __? == is_pid(pid)
+    assert is_pid(pid) == __?
   end
 
   think "You are a process" do


### PR DESCRIPTION
It seems throughout, the examples including comparisons have the expected value on the right hand side. This is contrary to how assertions are originally explained in "about asserts". Furthermore, in certain cases, when expected values are on the right side warnings are generated during compilation (https://github.com/iamvery/elixir-koans/pull/12/commits/36732ab3ed5c0f7241aede00cee57dd8f7fe54a7).
