### PR TITLE
Better user feedback

### DIFF
--- a/lib/koans.ex
+++ b/lib/koans.ex
@@ -1,8 +1,14 @@
 defmodule Koans.MeditateWarning do
   defexception [:message]
   def message(exception) do
-    # TODO include offending line of code in output
-    formatted_message = IO.ANSI.format([:magenta, :bright, "Please meditate: ", :blue, exception.message])
+    location = System.stacktrace |> Enum.at(1) |> elem(3)
+    formatted_message = IO.ANSI.format(
+    [
+      :magenta, :bright, "Please meditate: ",
+      :blue, :normal, exception.message,
+      :yellow, " (#{location[:file]}:#{location[:line]})"
+    ]
+    )
     "#{formatted_message}"
   end
 end

--- a/lib/koans.ex
+++ b/lib/koans.ex
@@ -68,6 +68,7 @@ defmodule Koans do
     |> focus
     |> Enum.reverse
     |> Enum.each(&exec/1)
+    congratulate
   end
 
   defp focus(koans) do
@@ -136,4 +137,10 @@ defmodule Koans do
       meditate @meditation <> "#{IO.ANSI.format([:red, " (replace with an assertion)"])}"
     end
   end
+
+  defp congratulate do
+    IO.ANSI.format([:green, "\n** You have learned much. You must find your own path now. **"])
+    |> IO.puts
+  end
+
 end


### PR DESCRIPTION
Two changes (both examples with a single koan given `@tag :focus`)

1) Add offending line of code to exception message:

![failure](https://cloud.githubusercontent.com/assets/338814/14687126/e739f780-0709-11e6-94c9-682a31f843df.png)

2) Congratulate the user if they finish

![success](https://cloud.githubusercontent.com/assets/338814/14687129/ec0eecb6-0709-11e6-8883-25f65173571e.png)

(I'd like to add some nice ASCII art of mountains to this, but didn't want to steal anybody's.)
