### PR TITLE
Remove extra "do" from example function def

### DIFF
--- a/lib/koans.ex
+++ b/lib/koans.ex
@@ -100,7 +100,7 @@ defmodule Koans do
       unless tag == :skip do
         Module.put_attribute(__MODULE__, :meditation, unquote(message))
         Koans.add({__MODULE__, unquote(name), tag})
-        def unquote(name)(), do: unquote(lesson)
+        def unquote(name)(), unquote(lesson)
       end
     end
   end


### PR DESCRIPTION
The quoted value of `lesson` already has a `do:` key, so no need to give
it another one in the function definition.
