### PR TITLE
Remove unneeded exit hook

### DIFF
--- a/lib/mix/tasks/learn.ex
+++ b/lib/mix/tasks/learn.ex
@@ -7,7 +7,7 @@ defmodule Mix.Tasks.Learn do
 
   def run(_) do
     Application.ensure_all_started(:koans)
-    System.at_exit(fn 0 -> Koans.Runner.run end)
     Koans.Lessons.load
+    Koans.Runner.run
   end
 end


### PR DESCRIPTION
For the mix task, they just run after they're loaded. There is no
concern to wait until the process is about to exit afaik. So run 'em!
